### PR TITLE
feat: expand payment breakdown UI

### DIFF
--- a/Untitled-2.html
+++ b/Untitled-2.html
@@ -84,11 +84,57 @@
                 <input id="card" type="number" min="0" step="1" inputmode="numeric" value="0" />
               </div>
               <div>
-                <label for="qr">QR/その他</label>
+                <label for="qr">ポイント</label>
                 <input id="qr" type="number" min="0" step="1" inputmode="numeric" value="0" />
               </div>
             </div>
             <div class="hint" id="payTotalHint">内訳合計：0円</div>
+          </div>
+
+          <div>
+            <label>支払項目</label>
+            <div class="grid g2">
+              <div>
+                <label for="payItem1">現金</label>
+                <input id="payItem1" type="number" min="0" step="1" inputmode="numeric" value="0" />
+              </div>
+              <div>
+                <label for="payItem2">ペイペイ</label>
+                <input id="payItem2" type="number" min="0" step="1" inputmode="numeric" value="0" />
+              </div>
+              <div>
+                <label for="payItem3">クレジット</label>
+                <input id="payItem3" type="number" min="0" step="1" inputmode="numeric" value="0" />
+              </div>
+              <div>
+                <label for="payItem4">項目4</label>
+                <input id="payItem4" type="number" min="0" step="1" inputmode="numeric" value="0" />
+              </div>
+              <div>
+                <label for="payItem5">項目5</label>
+                <input id="payItem5" type="number" min="0" step="1" inputmode="numeric" value="0" />
+              </div>
+              <div>
+                <label for="payItem6">項目6</label>
+                <input id="payItem6" type="number" min="0" step="1" inputmode="numeric" value="0" />
+              </div>
+              <div>
+                <label for="payItem7">項目7</label>
+                <input id="payItem7" type="number" min="0" step="1" inputmode="numeric" value="0" />
+              </div>
+              <div>
+                <label for="payItem8">項目8</label>
+                <input id="payItem8" type="number" min="0" step="1" inputmode="numeric" value="0" />
+              </div>
+              <div>
+                <label for="payItem9">項目9</label>
+                <input id="payItem9" type="number" min="0" step="1" inputmode="numeric" value="0" />
+              </div>
+              <div>
+                <label for="payItem10">項目10</label>
+                <input id="payItem10" type="number" min="0" step="1" inputmode="numeric" value="0" />
+              </div>
+            </div>
           </div>
 
           <div class="grid" style="grid-column:1/-1">


### PR DESCRIPTION
## Summary
- show points alongside cash and card in payment breakdown
- add placeholder fields for up to ten payment items

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a67a499394832b816a4a0ae85b1c5c