### PR TITLE
style: 支払項目の入力欄を整列し配色を明るく

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,43 +5,47 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>一日の売上入力（ローカル保存・CSV出力）</title>
   <style>
-    :root { --bg:#0b1020; --panel:#111933; --panel2:#0f1730; --text:#e9edf5; --muted:#9fb0d0; --acc:#6aa8ff; --danger:#ff6a6a; }
+    :root { --bg:#eef3ff; --panel:#ffffff; --panel2:#f5f7ff; --text:#0b1020; --muted:#4a5d86; --acc:#1e60d7; --danger:#d63c3c; }
     html,body{height:100%}
-    body{margin:0;background:linear-gradient(180deg,var(--bg),#0c1530);color:var(--text);font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,"Noto Sans JP",sans-serif}
+    body{margin:0;background:linear-gradient(180deg,var(--bg),#dfe8ff);color:var(--text);font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,"Noto Sans JP",sans-serif}
     .wrap{max-width:1100px;margin:0 auto;padding:20px 16px 80px}
     h1{font-size:clamp(20px,3.8vw,32px);margin:8px 0 12px}
     .grid{display:grid;gap:12px}
     .g2{grid-template-columns:repeat(2,minmax(0,1fr))}
     .g3{grid-template-columns:repeat(3,minmax(0,1fr))}
     @media(max-width:720px){.g2,.g3{grid-template-columns:1fr}}
-    .card{background:linear-gradient(180deg,var(--panel),var(--panel2));border:1px solid #1f2b52;border-radius:16px;box-shadow:0 10px 26px rgba(0,0,0,.2)}
-    .card-h{padding:14px 16px;border-bottom:1px solid #1d2a51;font-weight:600}
+    .card{background:linear-gradient(180deg,var(--panel),var(--panel2));border:1px solid #c8d5f3;border-radius:16px;box-shadow:0 4px 12px rgba(0,0,0,.05)}
+    .card-h{padding:14px 16px;border-bottom:1px solid #c8d5f3;font-weight:600}
     .card-c{padding:14px 16px}
     label{display:block;font-size:12px;color:var(--muted);margin-bottom:6px}
-    input,select,textarea{width:100%;box-sizing:border-box;background:#0c1430;color:var(--text);border:1px solid #213469;border-radius:10px;padding:10px 12px;font-size:14px}
-    input:focus,select:focus,textarea:focus{outline:2px solid #335fb0}
+    input,select,textarea{width:100%;box-sizing:border-box;background:#fff;color:var(--text);border:1px solid #b5c9f3;border-radius:10px;padding:10px 12px;font-size:14px}
+    input:focus,select:focus,textarea:focus{outline:2px solid var(--acc)}
     textarea{min-height:64px}
     .row{display:grid;grid-template-columns:1fr auto auto auto auto auto;gap:8px;align-items:center}
     .row input{padding:8px}
-    .tag{display:inline-block;font-size:12px;padding:4px 8px;border-radius:999px;background:#12224a;color:#cfe0ff;border:1px solid #284585}
-    .btn{appearance:none;border:1px solid #2a4e95;background:#12306a;color:#e6f0ff;padding:10px 14px;border-radius:12px;font-weight:600;cursor:pointer}
-    .btn:hover{filter:brightness(1.08)}
+    .pay-row{display:flex;gap:8px;align-items:center;margin-bottom:6px}
+    .pay-row .pay-name{width:120px;background:#fff;border:1px solid #b5c9f3;border-radius:10px;padding:8px 12px;font-size:14px;box-sizing:border-box}
+    .pay-row input{width:120px;padding:8px;text-align:right}
+    .pay-row.header span{border:none;background:transparent;font-weight:600;color:var(--muted);text-align:center;padding:0;width:120px}
+    .tag{display:inline-block;font-size:12px;padding:4px 8px;border-radius:999px;background:#e1e9ff;color:#1e2a44;border:1px solid #b5c9f3}
+    .btn{appearance:none;border:1px solid var(--acc);background:#fff;color:var(--acc);padding:10px 14px;border-radius:12px;font-weight:600;cursor:pointer}
+    .btn:hover{filter:brightness(0.96)}
     .btn:active{transform:translateY(1px)}
-    .btn.sub{background:#14203e}
-    .btn.ghost{background:transparent;border-color:#365aa3}
-    .btn.danger{background:#521e1e;border-color:#8a2c2c}
+    .btn.sub{background:#edf2ff}
+    .btn.ghost{background:transparent;border-color:#b5c9f3;color:var(--text)}
+    .btn.danger{background:#fff5f5;border-color:var(--danger);color:var(--danger)}
     .flex{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
     table{width:100%;border-collapse:collapse}
-    th,td{padding:10px 8px;border-bottom:1px solid #1d2a51;text-align:left;font-size:14px}
-    th{color:#c7d8ff;font-weight:700}
+    th,td{padding:10px 8px;border-bottom:1px solid #c8d5f3;text-align:left;font-size:14px}
+    th{color:#1e2a44;font-weight:700}
     .right{text-align:right}
     .muted{color:var(--muted)}
     .kpi{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:10px}
-    .kpi .box{background:#0c1430;border:1px solid #213469;border-radius:12px;padding:12px}
+    .kpi .box{background:#fff;border:1px solid #b5c9f3;border-radius:12px;padding:12px}
     .kpi .val{font-size:20px;font-weight:800}
     @media(max-width:820px){.kpi{grid-template-columns:repeat(2,minmax(0,1fr))}}
-    .hint{font-size:12px;color:#b9c7e6}
-    .pill{display:inline-flex;gap:6px;align-items:center;background:#0e1a39;border:1px solid #22407c;border-radius:999px;padding:6px 10px}
+    .hint{font-size:12px;color:#4a5d86}
+    .pill{display:inline-flex;gap:6px;align-items:center;background:#e1e9ff;border:1px solid #b5c9f3;border-radius:999px;padding:6px 10px}
   </style>
 </head>
 <body>
@@ -84,12 +88,84 @@
                 <input id="card" type="number" min="0" step="1" inputmode="numeric" value="0" />
               </div>
               <div>
-                <label for="qr">QR/その他</label>
+                <label for="qr">ポイント</label>
                 <input id="qr" type="number" min="0" step="1" inputmode="numeric" value="0" />
               </div>
             </div>
             <div class="hint" id="payTotalHint">内訳合計：0円</div>
           </div>
+
+          <div>
+            <label>支払項目</label>
+            <div id="payItems">
+              <div class="pay-row header">
+                <span class="pay-name">項目</span>
+                <span>10%</span>
+                <span>8%</span>
+                <span>合計</span>
+              </div>
+              <div class="pay-row">
+                <span class="pay-name">現金</span>
+                <input id="payItem1_10" class="i-tax10" type="number" min="0" step="1" inputmode="numeric" value="0" />
+                <input id="payItem1_8" class="i-tax8" type="number" min="0" step="1" inputmode="numeric" value="0" />
+                <input id="payItem1_total" class="i-total" type="number" readonly value="0" />
+              </div>
+              <div class="pay-row">
+                <span class="pay-name">ペイペイ</span>
+                <input id="payItem2_10" class="i-tax10" type="number" min="0" step="1" inputmode="numeric" value="0" />
+                <input id="payItem2_8" class="i-tax8" type="number" min="0" step="1" inputmode="numeric" value="0" />
+                <input id="payItem2_total" class="i-total" type="number" readonly value="0" />
+              </div>
+              <div class="pay-row">
+                <span class="pay-name">クレジット</span>
+                <input id="payItem3_10" class="i-tax10" type="number" min="0" step="1" inputmode="numeric" value="0" />
+                <input id="payItem3_8" class="i-tax8" type="number" min="0" step="1" inputmode="numeric" value="0" />
+                <input id="payItem3_total" class="i-total" type="number" readonly value="0" />
+              </div>
+              <div class="pay-row">
+                <span class="pay-name">項目4</span>
+                <input id="payItem4_10" class="i-tax10" type="number" min="0" step="1" inputmode="numeric" value="0" />
+                <input id="payItem4_8" class="i-tax8" type="number" min="0" step="1" inputmode="numeric" value="0" />
+                <input id="payItem4_total" class="i-total" type="number" readonly value="0" />
+              </div>
+              <div class="pay-row">
+                <span class="pay-name">項目5</span>
+                <input id="payItem5_10" class="i-tax10" type="number" min="0" step="1" inputmode="numeric" value="0" />
+                <input id="payItem5_8" class="i-tax8" type="number" min="0" step="1" inputmode="numeric" value="0" />
+                <input id="payItem5_total" class="i-total" type="number" readonly value="0" />
+              </div>
+              <div class="pay-row">
+                <span class="pay-name">項目6</span>
+                <input id="payItem6_10" class="i-tax10" type="number" min="0" step="1" inputmode="numeric" value="0" />
+                <input id="payItem6_8" class="i-tax8" type="number" min="0" step="1" inputmode="numeric" value="0" />
+                <input id="payItem6_total" class="i-total" type="number" readonly value="0" />
+              </div>
+              <div class="pay-row">
+                <span class="pay-name">項目7</span>
+                <input id="payItem7_10" class="i-tax10" type="number" min="0" step="1" inputmode="numeric" value="0" />
+                <input id="payItem7_8" class="i-tax8" type="number" min="0" step="1" inputmode="numeric" value="0" />
+                <input id="payItem7_total" class="i-total" type="number" readonly value="0" />
+              </div>
+              <div class="pay-row">
+                <span class="pay-name">項目8</span>
+                <input id="payItem8_10" class="i-tax10" type="number" min="0" step="1" inputmode="numeric" value="0" />
+                <input id="payItem8_8" class="i-tax8" type="number" min="0" step="1" inputmode="numeric" value="0" />
+                <input id="payItem8_total" class="i-total" type="number" readonly value="0" />
+              </div>
+              <div class="pay-row">
+                <span class="pay-name">項目9</span>
+                <input id="payItem9_10" class="i-tax10" type="number" min="0" step="1" inputmode="numeric" value="0" />
+                <input id="payItem9_8" class="i-tax8" type="number" min="0" step="1" inputmode="numeric" value="0" />
+                <input id="payItem9_total" class="i-total" type="number" readonly value="0" />
+              </div>
+              <div class="pay-row">
+                <span class="pay-name">項目10</span>
+                <input id="payItem10_10" class="i-tax10" type="number" min="0" step="1" inputmode="numeric" value="0" />
+                <input id="payItem10_8" class="i-tax8" type="number" min="0" step="1" inputmode="numeric" value="0" />
+                <input id="payItem10_total" class="i-total" type="number" readonly value="0" />
+              </div>
+            </div>
+            </div>
 
           <div class="grid" style="grid-column:1/-1">
             <div class="flex" style="justify-content:space-between">
@@ -268,6 +344,19 @@
 
     [cash,card,qr,customers].forEach(x=>x.addEventListener('input', recalcTotals));
 
+    function updatePayItemTotals(){
+      document.querySelectorAll('.pay-row').forEach(row=>{
+        const t10 = nOr0(row.querySelector('.i-tax10').value);
+        const t8 = nOr0(row.querySelector('.i-tax8').value);
+        row.querySelector('.i-total').value = t10 + t8;
+      });
+    }
+    document.querySelectorAll('.pay-row input').forEach(inp=>{
+      if(!inp.classList.contains('i-total')){
+        inp.addEventListener('input', updatePayItemTotals);
+      }
+    });
+
     document.getElementById('addRowBtn').addEventListener('click',()=>addRow());
     document.getElementById('clearForm').addEventListener('click',()=>{
       store.value = '';
@@ -422,6 +511,7 @@
     // 初期行
     addRow();
     recalcTotals();
+    updatePayItemTotals();
     renderList();
   </script>
 </body>


### PR DESCRIPTION
## Summary
- 配色を明るいトーンに変更し、全体の視認性を向上
- 支払項目に「10%」「8%」「合計」のヘッダーを追加
- 入力ボックスの幅とスタイルを統一して8桁まで見やすく整列

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a67a499394832b816a4a0ae85b1c5c